### PR TITLE
Add jpm as dev dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "firefox": ">=33.0a1",
     "fennec": ">=33.0a1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "jpm": "^1.0.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "Port of the chrome extension",
   "main": "index.js",
   "author": "",
+  "scripts": {
+    "run": "./node_modules/.bin/jpm run",
+    "build": "./node_modules/.bin/jpm xpi"
+  },
   "engines": {
     "firefox": ">=33.0a1",
     "fennec": ">=33.0a1"


### PR DESCRIPTION
Allowing to install all deps with:

``` shell
npm install
```

and 

``` shell
npm run build
```

or

``` shell
npm run build -b ./path/to/devedition run
```

to build.

What do you think?
